### PR TITLE
add functionality to refresh token + made error handling better if to…

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -10,6 +10,7 @@ const generatePassword = async (password) => {
 
 const generateJWT = (account) => {
   let jwtSecretKey = process.env.JWT_SECRET_KEY;
+  let jwtRefreshSecretKey = process.env.JWT_REFRESH_SECRET_KEY;
   let data = {
     time: moment.now().valueOf(),
     account_id: account.account_id,
@@ -17,19 +18,39 @@ const generateJWT = (account) => {
     last_name: account.last_name,
   };
 
-  const token = jwt.sign(data, jwtSecretKey, {expiresIn: '2h'});
-  return token;
+  const token = jwt.sign(data, jwtSecretKey, { expiresIn: "30m" });
+  const refreshToken = jwt.sign(data, jwtRefreshSecretKey, { expiresIn: "1d" });
+
+  return { token, refreshToken };
 };
 
 const verifyJWT = async (token) => {
   let jwtSecretKey = process.env.JWT_SECRET_KEY;
-  const verified = jwt.verify(token, jwtSecretKey);
-  if (verified) return verified;
-  else return null;
+  const verified = jwt.verify(token, jwtSecretKey, (err, decoded) => {
+    if (err) {
+      return null;
+    } else {
+      return decoded;
+    }
+  });
+  return verified;
+};
+
+const verifyRefreshJWT = async (token) => {
+  let jwtRefreshSecretKey = process.env.JWT_REFRESH_SECRET_KEY;
+  const verified = jwt.verify(token, jwtRefreshSecretKey, (err, decoded) => {
+    if (err) {
+      return null;
+    } else {
+      return decoded;
+    }
+  });
+  return verified;
 };
 
 module.exports = {
   generatePassword,
   generateJWT,
   verifyJWT,
+  verifyRefreshJWT,
 };

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,5 +13,6 @@ router.post("/login", controller.accountLogin);
 router.post("/account/create", controller.createAccount);
 router.delete("/account/delete", controller.deleteAccount);
 router.get("/account/id", controller.getAccountById);
+router.post("/account/refresh", controller.refreshToken);
 
 module.exports = router;


### PR DESCRIPTION
Added refreshToken route

When logging in, the request to get a token will now also return a refresh token, which is good for 1d. Can send POST to `/api/v1/account/refresh` with body

`{
    "refreshToken": ${refreshToken}
}`

if the refresh token is valid, will return new token and refresh token. If it isn't, 406 unacceptable error.